### PR TITLE
Fix ADD zero flag logic and add test

### DIFF
--- a/src/Core/Z80Cpu.cs
+++ b/src/Core/Z80Cpu.cs
@@ -397,9 +397,9 @@ public class Z80Cpu
     private void AddToA(byte value)
     {
         int result = A + value;
-        SetZeroFlag(result == 0);
-        SetCarryFlag(result > 255);
-        A = (byte)(result & Z80OpCode.BYTE_MASK);
+        SetZeroFlag((result & 0xFF) == 0);
+        SetCarryFlag(result > 0xFF);
+        A = (byte)result;
     }
     
     private byte IncByte(byte value)

--- a/tests/Core.Tests/Z80CpuTests.cs
+++ b/tests/Core.Tests/Z80CpuTests.cs
@@ -370,6 +370,21 @@ public class Z80CpuTests
         Assert.True((cpu.F & 0x40) != 0);
     }
 
+    [Fact]
+    public void ADD_OverflowSetsZeroFlag()
+    {
+        // Arrange
+        var cpu = CreateCpuWithMemory(new byte[] { 0x3E, 0xFF, 0xC6, 0x01 }); // LD A, FFh; ADD A, 01h
+
+        // Act
+        cpu.Step(); // Load A
+        cpu.Step(); // Add (result wraps to 0)
+
+        // Assert
+        Assert.Equal(0x00, cpu.A);
+        Assert.True((cpu.F & 0x40) != 0); // Zero flag set
+    }
+
     #endregion
 
     #region Increment/Decrement Tests


### PR DESCRIPTION
## Summary
- correct `AddToA` zero and carry flag computation
- test overflow case where zero flag should be set

## Testing
- `dotnet test --no-restore --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686dc7b653c0832ebac7984414c315b6