### PR TITLE
Update EmulatedTimeSeconds calculation

### DIFF
--- a/src/Core/Z80Cpu.cs
+++ b/src/Core/Z80Cpu.cs
@@ -52,9 +52,10 @@ public class Z80Cpu
     }
 
     /// <summary>
-    /// Emulated time elapsed in seconds based on cycle count at 4MHz.
+    /// Emulated time elapsed in seconds based on cycle count and configured clock frequency.
     /// </summary>
-    public double EmulatedTimeSeconds => (double)_totalCycles / Z80CycleTiming.CLOCK_FREQUENCY_HZ;
+    public double EmulatedTimeSeconds =>
+        _totalCycles / (Options.ClockMHz * 1_000_000.0);
 
     public void Reset()
     {

--- a/tests/Core.Tests/Z80CpuTests.cs
+++ b/tests/Core.Tests/Z80CpuTests.cs
@@ -751,14 +751,31 @@ public class Z80CpuTests
     [Fact]
     public void EmulatedTimeSeconds_CalculatesCorrectly()
     {
-        // Arrange
+        // Arrange - default clock frequency from options
         var cpu = CreateCpuWithMemory(new byte[] { Z80OpCode.NOP });
-        
+
         // Act
         cpu.Step(); // 4 cycles
-        
-        // Assert - 4 cycles at 4MHz should be 1 microsecond
-        var expectedTime = 4.0 / Z80CycleTiming.CLOCK_FREQUENCY_HZ;
+
+        // Assert - cycles divided by configured frequency
+        var expectedTime = 4.0 / (cpu.Options.ClockMHz * 1_000_000.0);
+        Assert.Equal(expectedTime, cpu.EmulatedTimeSeconds, 10);
+    }
+
+    [Fact]
+    public void EmulatedTimeSeconds_UsesCustomClockFrequency()
+    {
+        // Arrange - create CPU with custom 8MHz clock
+        var memory = new MsxMemoryMap();
+        var options = new Z80CpuOptions { RomSize = 1024, RamSize = 1024, ClockMHz = 8.0 };
+        var cpu = new Z80Cpu(memory, options);
+        memory.LoadRom(new byte[] { Z80OpCode.NOP });
+
+        // Act
+        cpu.Step(); // 4 cycles
+
+        // Assert - cycles divided by custom frequency
+        var expectedTime = 4.0 / (options.ClockMHz * 1_000_000.0);
         Assert.Equal(expectedTime, cpu.EmulatedTimeSeconds, 10);
     }
 


### PR DESCRIPTION
## Summary
- compute emulated time using `ClockMHz`
- update tests to respect default frequency
- add a new test for custom clock values

## Testing
- `dotnet test` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dc7be1a30832e9705ffb353497c64