### PR TITLE
Clarify Z80 CPU instruction coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ It is built in **C# with .NET 8**, featuring clean architecture, full observabil
 - 🧪 Designed for testability, extensibility, and learning
 - ⚙️ Optional hardware offload via USB-C (FPGA + ESP32) — modular and non-required
 
+> **Note:** The Z80 CPU currently implements only a subset of instructions. Additional coverage is planned.
+
 ---
 
 ## 🚀 Getting Started
@@ -61,7 +63,7 @@ All core project documents are located in the [`/docs/project`](docs/project) fo
 Comprehensive component design specifications are in [`/docs/design`](docs/design):
 
 - [🏗️ Design Index](docs/design/README.md) - Navigation and overview
-- [🧮 Z80 CPU Core](docs/design/Core/Z80Cpu.md) - Complete CPU implementation details
+- [🧮 Z80 CPU Core](docs/design/Core/Z80Cpu.md) - CPU implementation details (partial instruction coverage)
 - Additional component designs (planned)
 
 ---

--- a/docs/design/Core/Z80Cpu.md
+++ b/docs/design/Core/Z80Cpu.md
@@ -6,7 +6,7 @@ This document provides detailed design specifications for the Z80 CPU emulation 
 
 ## 📋 Overview
 
-The Z80 CPU core (`Z80Cpu`) is the heart of the Zenix emulator, providing cycle-accurate emulation of the Zilog Z80 microprocessor as used in MSX computers. The implementation focuses on timing precision, maintainability, and comprehensive instruction support.
+The Z80 CPU core (`Z80Cpu`) is the heart of the Zenix emulator, providing cycle-accurate emulation of the Zilog Z80 microprocessor as used in MSX computers. The implementation focuses on timing precision, maintainability, and currently covers a subset of instructions, with more support planned.
 
 ---
 
@@ -480,7 +480,7 @@ Based on demonstration runs:
 |---------|------|---------|
 | 1.0 | 2025-07-08 | Initial implementation with cycle-accurate timing |
 | | | 64-bit cycle counter for 10+ year operation |
-| | | Comprehensive instruction set coverage |
+| | | Initial subset of the instruction set implemented; further coverage planned |
 | | | Complete unit test suite (47 tests) |
 
 ---


### PR DESCRIPTION
## Summary
- update Z80Cpu design doc to mention partial instruction support
- note partial CPU status in README

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686dc7bf53f4832eb73854f5fc7826b0